### PR TITLE
update: 実況モードをドメインごとに設定

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -538,10 +538,10 @@ class ComposeActivity :
             eventHub.dispatch(PreferenceChangedEvent(PREF_USE_DEFAULT_TAG))
         }
 
-        binding.editTextDefaultText.setText(preferences.getString(PREF_DEFAULT_TAG, ""))
+        binding.editTextDefaultText.setText(preferences.getString("${PREF_DEFAULT_TAG}_${accountManager.activeAccount?.domain?:""}", ""))
         binding.editTextDefaultText.doAfterTextChanged {
             preferences.edit()
-                .putString(PREF_DEFAULT_TAG, it.toString())
+                .putString("${PREF_DEFAULT_TAG}_${accountManager.activeAccount?.domain?:""}", it.toString())
                 .apply()
             eventHub.dispatch(PreferenceChangedEvent(PREF_DEFAULT_TAG))
         }

--- a/app/src/main/java/net/accelf/yuito/QuickTootView.kt
+++ b/app/src/main/java/net/accelf/yuito/QuickTootView.kt
@@ -103,7 +103,7 @@ class QuickTootView @JvmOverloads constructor(
 
     private fun syncDefaultTag() {
         viewModel.defaultTag.value = if (preference.getBoolean(PREF_USE_DEFAULT_TAG, false)) {
-            preference.getString(PREF_DEFAULT_TAG, null)
+            preference.getString("${PREF_DEFAULT_TAG}_${viewModel.account.domain}", null)
         } else {
             null
         }

--- a/app/src/main/java/net/accelf/yuito/QuickTootViewModel.kt
+++ b/app/src/main/java/net/accelf/yuito/QuickTootViewModel.kt
@@ -20,7 +20,7 @@ class QuickTootViewModel @Inject constructor(
     private val sharedPreferences: SharedPreferences,
 ) : ViewModel() {
 
-    private val account = accountManager.activeAccount!!
+    val account = accountManager.activeAccount!!
 
     private val unleakableAllowed by lazy { CAN_USE_UNLEAKABLE.contains(account.domain) }
 


### PR DESCRIPTION
## 変更の概要

* 「実況者モード」をドメインごとに別のPreferenceキーで保存

## なぜこの変更をするのか

* インスタンス固有でつけたいハッシュタグを誤って別インスタンスでつけてしまうことを防ぐため。

## やったこと

* [x] preferenceのキーにsuffixとしてドメイン名を設定
* [x] TootViewModelからドメイン名を取得するため、QuickTootViewModelのaccountのprivateを外した

## 影響範囲

* 初回起動時、既存のハッシュタグがリセットされる

## 課題

* アーキテクチャ的にaccountのprivateを外すことが不適切であれば、ご指摘願います。

## 備考

* Branchにdevelopがなかったため、masterにpull requestが飛んでしまっていると思います。